### PR TITLE
lnvargus -> lnvargus_socketclient

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ CC := g++
 GST_INSTALL_DIR?=/usr/lib/aarch64-linux-gnu/gstreamer-1.0/
 LIB_INSTALL_DIR?=/usr/lib/aarch64-linux-gnu/tegra/
 CFLAGS:=
-LIBS:= -lnvbuf_utils -lnvdsbufferpool -lnvargus -lpthread
+LIBS:= -lnvbuf_utils -lnvdsbufferpool -lnvargus_socketclient -lpthread
 
 SRCS := $(wildcard ./src/*.cpp)
 


### PR DESCRIPTION
As described [here](https://forums.developer.nvidia.com/t/nvarguscamerasrc-built-from-source-isp-error/178939/3) using nvargus_socketclient fix [this kind of errors](https://forums.developer.nvidia.com/t/writing-a-custom-gstreamer-plugin/154362/10), tested on my side on jetson nano