### PR TITLE
Metadata bindings for Python

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -139,3 +139,23 @@ libgstnvmanualcamerasrc = library(meson.project_name(), gstnvmanualcamerasrc_src
   install_dir: gst_install_dir,
   cpp_args: [gstnvmanualcamerasrc_cflags, gstnvmanualcamera_metadata_cflags],
 )
+
+python3 = import('python').find_installation('python3')
+if python3.found() and dependency('python3', required:false).found()
+  message('Building `nvmanual` python3 module.')
+  pymod = python3.extension_module('nvmanual',
+    sources: ['pymod.cpp'],
+    dependencies: [
+      dependency('python3'),
+      dependency('pybind11'),
+      gstnvmanualcamera_metadata_deps,
+    ],
+    link_with: libgstnvmanualcamerameta,
+    include_directories: [gstnvmanualcamerasrc_incdirs, mmapi_incdirs],
+    cpp_args: gstnvmanualcamera_metadata_cflags,
+    install: true,
+  )
+  pymod_path = meson.current_build_dir()
+else
+  message('Python3 not found. Not building python module.')
+endif

--- a/src/pymod.cpp
+++ b/src/pymod.cpp
@@ -71,6 +71,15 @@ PYBIND11_MODULE(nvmanual, m) {
   declare_bayer_tuple<float>(m_argus, "Float");  // argus.FloatBayerTuple
   declare_bayer_tuple<uint32_t>(m_argus, "Int");  // argus.IntBayerTuple
 
+  // This isn't an enum because Nvidia rolled it's own C++ 03 thing.
+  // FIXME(mdegans): figure out how to bind this
+  // py::enum_<Argus::AeState>(m_argus, "AeState")
+  //   .value("INACTIVE", Argus::AE_STATE_INACTIVE)
+  //   .value("SEARCHING", Argus::AE_STATE_SEARCHING)
+  //   .value("CONVERGED", Argus::AE_STATE_CONVERGED)
+  //   .value("FLASH_REQUIRED", Argus::AE_STATE_FLASH_REQUIRED)
+  //   .value("TIMEOUT", Argus::AE_STATE_TIMEOUT);  // argus.AeState
+
   py::class_<nvmanualcam::Metadata> c_metadata(m, "Metadata");
   c_metadata.def_static("from_buffer", [](py::object pygobject_buf) {
       // reinterpret_cast is now Nvidia does this in the `nvds` bindings.
@@ -96,4 +105,42 @@ PYBIND11_MODULE(nvmanual, m) {
   ).doc() = "Get the sharpness score for the image or a ROI within it.";
   c_metadata.def("tonemap_curves", &nvmanualcam::Metadata::getToneMapCurves)
     .doc() = "Get tonemap curves (if enabled, else retursn None)";
+  c_metadata.def_property_readonly("ae_locked", &nvmanualcam::Metadata::getAeLocked)
+    .doc() = "Returns true if Auto Exposure was locked for this capture.";
+  // c_metadata.def_property_readonly("ae_state", &nvmanualcam::Metadata::getAeState)
+  //   .doc() = "Get Auto Exposure state for this capture";
+  c_metadata.def_property_readonly("awb_cct", &nvmanualcam::Metadata::getAwbCct)
+    .doc() = "Get Auto White Balance CCT (color temperature in Kelvin)";
+  c_metadata.def_property_readonly("awb_gains", &nvmanualcam::Metadata::getAwbGains)
+    .doc() = "Get Auto White Balance gains.";
+  // TODO(AE Regions and Argus::AcRegion)
+  // TODO(AWB Regions, AWB Mode, AWB State)
+  c_metadata.def("awb_estimate", &nvmanualcam::Metadata::getAwbWbEstimate)
+    .doc() = "Get Auto White Balance estimate (if available, else returns None)";
+  c_metadata.def_property_readonly("capture_id", &nvmanualcam::Metadata::getCaptureId)
+    .doc() = "Get capture id (close, but not quite the frame number)";
+  c_metadata.def("color_correction_matrix", &nvmanualcam::Metadata::getColorCorrectionMatrix)
+    .doc() = "Get color correction matrix for this capture (if available else None()";
+  c_metadata.def_property_readonly("color_correction_matrix_enable", &nvmanualcam::Metadata::getColorCorrectionMatrixEnable)
+    .doc() = "Returns true if color correction matrix is enabled for this capture.";
+  c_metadata.def_property_readonly("saturation", &nvmanualcam::Metadata::getColorSaturation)
+    .doc() = "Get saturation for this capture (0.0 - 1.0)";
+  // TODO(Argus::AeFlickerState)
+  c_metadata.def_property_readonly("focuser_position", &nvmanualcam::Metadata::getFocuserPosition)
+    .doc() = "Get focuser position (if applicable, else value is useless)";
+  c_metadata.def_property_readonly("frame_duration", &nvmanualcam::Metadata::getFrameDuration)
+    .doc() = "Get the duration it took to generate the associated frame in NS";
+  c_metadata.def_property_readonly("frame_readout_time", &nvmanualcam::Metadata::getFrameReadoutTime)
+    .doc() = "Get the frame readout time in NS.";
+  c_metadata.def_property_readonly("isp_digital_gain", &nvmanualcam::Metadata::getIspDigitalGain)
+    .doc() = "Get the ISP digital gain for this capture.";
+  c_metadata.def_property_readonly("sensor_analog_gain", &nvmanualcam::Metadata::getSensorAnalogGain)
+    .doc() = "Get the analog gain for this capture.";
+  c_metadata.def_property_readonly("sensor_exposure_time", &nvmanualcam::Metadata::getSensorExposureTime)
+    .doc() = "Get the sensor exposure time (in NS)";
+  c_metadata.def_property_readonly("sensor_sensitivity", &nvmanualcam::Metadata::getSensorSensitivity)
+    .doc() = "Get the sensor sensitivity (ISO value)";
+  c_metadata.def_property_readonly("sensor_timestamp", &nvmanualcam::Metadata::getSensorTimestamp)
+    .doc() = "Get the sensor timestamp.";
+  // TODO(Argus::Array2D, getSharpnessValues)
 }

--- a/src/pymod.cpp
+++ b/src/pymod.cpp
@@ -18,23 +18,23 @@
 namespace py = pybind11;
 
 // // https://stackoverflow.com/questions/47487888/pybind11-template-class-of-many-types/47749076
-// template <typename T>
-// void declare_rectangle(py::module& m, std::string typestr) {
-//   py::class_<Argus::Rectangle<T>>(m, typestr + std::string("Rectangle"))
-//     .def(py::init<T, T, T, T>(), py::arg("left"), py::arg("top"), py::arg("right"), py::arg("bottom"))
-//     .def_property_readonly("left", py::overload_cast<>(&Argus::Rectangle<T>::left))
-//     .def_property_readonly("top", py::overload_cast<>(&Argus::Rectangle<T>::top))
-//     .def_property_readonly("right", py::overload_cast<>(&Argus::Rectangle<T>::right))
-//     .def_property_readonly("bottom", py::overload_cast<>(&Argus::Rectangle<T>::bottom));
-// }
+template <typename T>
+void declare_rectangle(py::module& m, std::string typestr) {
+  py::class_<Argus::Rectangle<T>>(m, (typestr + std::string("Rectangle")).c_str())
+    .def(py::init<T, T, T, T>(), py::arg("left"), py::arg("top"), py::arg("right"), py::arg("bottom"))
+    .def_property_readonly("left", py::overload_cast<>(&Argus::Rectangle<T>::left))
+    .def_property_readonly("top", py::overload_cast<>(&Argus::Rectangle<T>::top))
+    .def_property_readonly("right", py::overload_cast<>(&Argus::Rectangle<T>::right))
+    .def_property_readonly("bottom", py::overload_cast<>(&Argus::Rectangle<T>::bottom));
+}
 
 
 PYBIND11_MODULE(nvmanual, m) {
 
   py::module argus = m.def_submodule("argus", "Unofficial Argus bindings");
 
-  // declare_rectangle<float>(argus, "Float");  // argus.FloatRectangle
-  // declare_rectangle<uint32_t>(argus, "Int");  // argus.IntRectangle
+  declare_rectangle<float>(argus, "Float");  // argus.FloatRectangle
+  declare_rectangle<uint32_t>(argus, "Int");  // argus.IntRectangle
 
   py::class_<nvmanualcam::Metadata> c_metadata(m, "Metadata");
   c_metadata.def_static("from_buffer", [](py::object pygobject_buf) {

--- a/src/pymod.cpp
+++ b/src/pymod.cpp
@@ -1,0 +1,57 @@
+#include <stdexcept>
+#include <string>
+// #include <Argus/Argus.h>
+// #include <bits/stdint-uintn.h>
+
+#include "gst/gst.h"
+
+#include "gst/gstbuffer.h"
+#include "gst/gstpad.h"
+#include "pybind11/pybind11.h"
+#include "pybind11/operators.h"
+#include "pybind11/cast.h"
+#include "pybind11/detail/common.h"
+
+#include "metadata.hpp"
+#include "pybind11/pytypes.h"
+
+namespace py = pybind11;
+
+// // https://stackoverflow.com/questions/47487888/pybind11-template-class-of-many-types/47749076
+// template <typename T>
+// void declare_rectangle(py::module& m, std::string typestr) {
+//   py::class_<Argus::Rectangle<T>>(m, typestr + std::string("Rectangle"))
+//     .def(py::init<T, T, T, T>(), py::arg("left"), py::arg("top"), py::arg("right"), py::arg("bottom"))
+//     .def_property_readonly("left", py::overload_cast<>(&Argus::Rectangle<T>::left))
+//     .def_property_readonly("top", py::overload_cast<>(&Argus::Rectangle<T>::top))
+//     .def_property_readonly("right", py::overload_cast<>(&Argus::Rectangle<T>::right))
+//     .def_property_readonly("bottom", py::overload_cast<>(&Argus::Rectangle<T>::bottom));
+// }
+
+
+PYBIND11_MODULE(nvmanual, m) {
+
+  py::module argus = m.def_submodule("argus", "Unofficial Argus bindings");
+
+  // declare_rectangle<float>(argus, "Float");  // argus.FloatRectangle
+  // declare_rectangle<uint32_t>(argus, "Int");  // argus.IntRectangle
+
+  py::class_<nvmanualcam::Metadata> c_metadata(m, "Metadata");
+  c_metadata.def_static("from_buffer", [](py::object pygobject_buf) {
+      // reinterpret_cast is now Nvidia does this in the `nvds` bindings.
+      // They require the user call `__hash__`, but we can do that for them and
+      // check we actually got a GstBuffer (as much as GObject can ensure that
+      // anyhow)
+      auto buf = reinterpret_cast<GstBuffer*>(py::hash(pygobject_buf));
+      if (!GST_IS_BUFFER(buf)) {
+        throw std::invalid_argument("Not a valid Gst.Buffer");
+      }
+      return nvmanualcam::Metadata::create(buf);
+    }, py::arg("buf")).doc() = "create nvmanual.Metadata from a Gst.Buffer";
+    // .def("bayer_histogram", &nvmanualcam::Metadata::getBayerHistogram)
+    // .def("rgb_histogram", &nvmanualcam::Metadata::getRgbHistogram)
+  c_metadata.def("scene_lux", &nvmanualcam::Metadata::getSceneLux);
+    // .def("sharpness_values", &nvmanualcam::Metadata::getSharpnessValues)
+    // .def("tonemap_curve", &nvmanualcam::Metadata::getToneMapCurves)
+    // .def("color_correction_matrix", &nvmanualcam::Metadata::getBayerHistogram);
+}

--- a/src/pymod.cpp
+++ b/src/pymod.cpp
@@ -94,6 +94,6 @@ PYBIND11_MODULE(nvmanual, m) {
     py::overload_cast<Argus::Rectangle<float>>(&nvmanualcam::Metadata::getSharpnessScore),
     py::arg("rect") = Argus::Rectangle<float>(0.0, 0.0, 1.0, 1.0)
   ).doc() = "Get the sharpness score for the image or a ROI within it.";
-    // .def("tonemap_curve", &nvmanualcam::Metadata::getToneMapCurves)
-    // .def("color_correction_matrix", &nvmanualcam::Metadata::getBayerHistogram);
+  c_metadata.def("tonemap_curves", &nvmanualcam::Metadata::getToneMapCurves)
+    .doc() = "Get tonemap curves (if enabled, else retursn None)";
 }

--- a/src/pymod.cpp
+++ b/src/pymod.cpp
@@ -1,89 +1,114 @@
 #include <bits/stdint-uintn.h>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
-#include <memory>
 
 #include <Argus/Argus.h>
 
 #include "gst/gst.h"
 #include "gst/gstbuffer.h"
 
-// #include "pybind11/attr.h"
 #include "pybind11/pybind11.h"
 #include "pybind11/detail/common.h"
 #include "pybind11/operators.h"
-#include "pybind11/cast.h"
-#include "pybind11/stl.h"
 #include "pybind11/pytypes.h"
+#include "pybind11/stl.h"
 
 #include "metadata.hpp"
 
 namespace py = pybind11;
 
-// // https://stackoverflow.com/questions/47487888/pybind11-template-class-of-many-types/47749076
+// //
+// https://stackoverflow.com/questions/47487888/pybind11-template-class-of-many-types/47749076
 template <typename T>
 void declare_rectangle(py::module& m, std::string typestr) {
   py::class_<Argus::Rectangle<T>>(m, (typestr + "Rectangle").c_str())
-    .def(py::init<T, T, T, T>(), py::arg("left"), py::arg("top"), py::arg("right"), py::arg("bottom"))
-    .def_property_readonly("left", py::overload_cast<>(&Argus::Rectangle<T>::left))
-    .def_property_readonly("top", py::overload_cast<>(&Argus::Rectangle<T>::top))
-    .def_property_readonly("right", py::overload_cast<>(&Argus::Rectangle<T>::right))
-    .def_property_readonly("bottom", py::overload_cast<>(&Argus::Rectangle<T>::bottom));
+      .def(py::init<T, T, T, T>(), py::arg("left"), py::arg("top"),
+           py::arg("right"), py::arg("bottom"))
+      .def_property_readonly("left",
+                             py::overload_cast<>(&Argus::Rectangle<T>::left))
+      .def_property_readonly("top",
+                             py::overload_cast<>(&Argus::Rectangle<T>::top))
+      .def_property_readonly("right",
+                             py::overload_cast<>(&Argus::Rectangle<T>::right))
+      .def_property_readonly("bottom",
+                             py::overload_cast<>(&Argus::Rectangle<T>::bottom));
 }
 
 template <typename T>
 void declare_rgb_tuple(py::module& m, std::string typestr) {
   py::class_<Argus::RGBTuple<T>>(m, (typestr + "RGBTuple").c_str())
-    .def(py::init<T, T, T>(), py::arg("r"), py::arg("g"), py::arg("b"))
-    .def_property_readonly("r", py::overload_cast<>(&Argus::RGBTuple<T>::r))
-    .def_property_readonly("g", py::overload_cast<>(&Argus::RGBTuple<T>::g))
-    .def_property_readonly("b", py::overload_cast<>(&Argus::RGBTuple<T>::b));
+      .def(py::init<T, T, T>(), py::arg("r"), py::arg("g"), py::arg("b"))
+      .def_property_readonly("r", py::overload_cast<>(&Argus::RGBTuple<T>::r))
+      .def_property_readonly("g", py::overload_cast<>(&Argus::RGBTuple<T>::g))
+      .def_property_readonly("b", py::overload_cast<>(&Argus::RGBTuple<T>::b));
 }
 
 template <typename T>
 void declare_bayer_tuple(py::module& m, std::string typestr) {
   py::class_<Argus::BayerTuple<T>>(m, (typestr + "BayerTuple").c_str())
-    .def(py::init<T, T, T, T>(), py::arg("r"), py::arg("g_even"), py::arg("g_odd"), py::arg("b"))
-    .def_property_readonly("r", py::overload_cast<>(&Argus::BayerTuple<T>::r))
-    .def_property_readonly("g_even", py::overload_cast<>(&Argus::BayerTuple<T>::gEven))
-    .def_property_readonly("g_odd", py::overload_cast<>(&Argus::BayerTuple<T>::gOdd))
-    .def_property_readonly("b", py::overload_cast<>(&Argus::BayerTuple<T>::b));
+      .def(py::init<T, T, T, T>(), py::arg("r"), py::arg("g_even"),
+           py::arg("g_odd"), py::arg("b"))
+      .def_property_readonly("r", py::overload_cast<>(&Argus::BayerTuple<T>::r))
+      .def_property_readonly("g_even",
+                             py::overload_cast<>(&Argus::BayerTuple<T>::gEven))
+      .def_property_readonly("g_odd",
+                             py::overload_cast<>(&Argus::BayerTuple<T>::gOdd))
+      .def_property_readonly("b",
+                             py::overload_cast<>(&Argus::BayerTuple<T>::b));
 }
 
 template <typename T>
 void declare_array_2d(py::module& m, std::string typestr) {
-    py::class_<Argus::Array2D<T>>(m, (typestr + "Array2D").c_str())
-      .def_static("from_xy", [](uint32_t x, uint32_t y){
-        return std::make_unique<Argus::Array2D<T>>(Argus::Size2D(x, y));
-      }, py::arg("x"), py::arg("y"))
-      .def("__len__", [](const Argus::Array2D<T> &a){ return a.size().area(); })
-      .def("__iter__", [](const Argus::Array2D<T> &a) {
-        return py::make_iterator(a.begin(), a.end());
-      }, py::keep_alive<0, 1>())
-      .def("__getitem__", [](const Argus::Array2D<T> &a, uint32_t index) {
-        // We need to raise a python error since the assert in Types.h can't be
-        // caught.  checkIndex being public would have been handy here.
-        if (index >= a.size().area()) {
-          std::stringstream ss;
-          ss << "Index " << index << " is out of range for this Array2D (max " << a.size().area() << ")";
-          throw py::index_error(ss.str());
-        }
-        return a[index];
-      })
-      .def("at", [](const Argus::Array2D<T> a, uint32_t x, uint32_t y) {
-        if (x >= a.size().width()) {
-          std::stringstream ss;
-          ss << "X index is out of range for this Array2d (max " << a.size().width() << ")";
-          throw py::index_error(ss.str());
-        }
-        if (y >= a.size().height()) {
-          std::stringstream ss;
-          ss << "Y index is out of range for this Array2d (max " << a.size().height() <<  ")";
-          throw py::index_error(ss.str());
-        }
-        return a(x, y);
-      }, py::arg("x"), py::arg("y")).doc() = "Access elements by x, y";
+  py::class_<Argus::Array2D<T>>(m, (typestr + "Array2D").c_str())
+      .def_static(
+          "from_xy",
+          [](uint32_t x, uint32_t y) {
+            return std::make_unique<Argus::Array2D<T>>(Argus::Size2D(x, y));
+          },
+          py::arg("x"), py::arg("y"))
+      .def("__len__",
+           [](const Argus::Array2D<T>& a) { return a.size().area(); })
+      .def(
+          "__iter__",
+          [](const Argus::Array2D<T>& a) {
+            return py::make_iterator(a.begin(), a.end());
+          },
+          py::keep_alive<0, 1>())
+      .def("__getitem__",
+           [](const Argus::Array2D<T>& a, uint32_t index) {
+             // We need to raise a python error since the assert in Types.h
+             // can't be caught.  checkIndex being public would have been handy
+             // here.
+             if (index >= a.size().area()) {
+               std::stringstream ss;
+               ss << "Index " << index
+                  << " is out of range for this Array2D (max "
+                  << a.size().area() << ")";
+               throw py::index_error(ss.str());
+             }
+             return a[index];
+           })
+      .def(
+          "at",
+          [](const Argus::Array2D<T> a, uint32_t x, uint32_t y) {
+            if (x >= a.size().width()) {
+              std::stringstream ss;
+              ss << "X index is out of range for this Array2d (max "
+                 << a.size().width() << ")";
+              throw py::index_error(ss.str());
+            }
+            if (y >= a.size().height()) {
+              std::stringstream ss;
+              ss << "Y index is out of range for this Array2d (max "
+                 << a.size().height() << ")";
+              throw py::index_error(ss.str());
+            }
+            return a(x, y);
+          },
+          py::arg("x"), py::arg("y"))
+      .doc() = "Access elements by x, y";
 }
 
 // because pybind doesn't detect this correctly on ubuntu 20.04 (or 18.04)]
@@ -98,18 +123,17 @@ struct type_caster<std::experimental::optional<T>>
 }  // namespace detail
 }  // namespace pybind11
 
-
 PYBIND11_MODULE(nvmanual, m) {
-
   py::module m_argus = m.def_submodule("argus", "Unofficial Argus bindings");
 
-  declare_rectangle<float>(m_argus, "Float");  // argus.FloatRectangle
-  declare_rectangle<uint32_t>(m_argus, "Int");  // argus.IntRectangle
-  declare_rgb_tuple<float>(m_argus, "Float");  // argus.FloatRGBTuple
-  declare_rgb_tuple<uint32_t>(m_argus, "Int");  // argus.IntRGBTuple
-  declare_bayer_tuple<float>(m_argus, "Float");  // argus.FloatBayerTuple
+  declare_rectangle<float>(m_argus, "Float");     // argus.FloatRectangle
+  declare_rectangle<uint32_t>(m_argus, "Int");    // argus.IntRectangle
+  declare_rgb_tuple<float>(m_argus, "Float");     // argus.FloatRGBTuple
+  declare_rgb_tuple<uint32_t>(m_argus, "Int");    // argus.IntRGBTuple
+  declare_bayer_tuple<float>(m_argus, "Float");   // argus.FloatBayerTuple
   declare_bayer_tuple<uint32_t>(m_argus, "Int");  // argus.IntBayerTuple
-  declare_array_2d<Argus::BayerTuple<float>>(m_argus, "FloatBayerTuple");  // argus.FloatBayerTupleArray2D
+  declare_array_2d<Argus::BayerTuple<float>>(
+      m_argus, "FloatBayerTuple");  // argus.FloatBayerTupleArray2D
 
   // This isn't an enum because Nvidia rolled it's own C++ 03 thing.
   // FIXME(mdegans): figure out how to bind this
@@ -121,67 +145,105 @@ PYBIND11_MODULE(nvmanual, m) {
   //   .value("TIMEOUT", Argus::AE_STATE_TIMEOUT);  // argus.AeState
 
   py::class_<nvmanualcam::Metadata> c_metadata(m, "Metadata");
-  c_metadata.def_static("from_buffer", [](py::object pygobject_buf) {
-      // reinterpret_cast is now Nvidia does this in the `nvds` bindings.
-      // They require the user call `__hash__`, but we can do that for them and
-      // check we actually got a GstBuffer (as much as GObject can ensure that
-      // anyhow)
-      auto buf = reinterpret_cast<GstBuffer*>(py::hash(pygobject_buf));
-      if (!GST_IS_BUFFER(buf)) {
-        throw std::invalid_argument("Not a valid Gst.Buffer");
-      }
-      return nvmanualcam::Metadata::create(buf);
-    }, py::arg("buf")).doc() = "create nvmanual.Metadata from a Gst.Buffer";
+  c_metadata
+      .def_static(
+          "from_buffer",
+          [](py::object pygobject_buf) {
+            // reinterpret_cast is now Nvidia does this in the `nvds` bindings.
+            // They require the user call `__hash__`, but we can do that for
+            // them and check we actually got a GstBuffer (as much as GObject
+            // can ensure that anyhow)
+            auto buf = reinterpret_cast<GstBuffer*>(py::hash(pygobject_buf));
+            if (!GST_IS_BUFFER(buf)) {
+              throw std::invalid_argument("Not a valid Gst.Buffer");
+            }
+            return nvmanualcam::Metadata::create(buf);
+          },
+          py::arg("buf"))
+      .doc() = "create nvmanual.Metadata from a Gst.Buffer";
   c_metadata.def("bayer_histogram", &nvmanualcam::Metadata::getBayerHistogram)
-    .doc() = "Get histogram of bayer data (if enabled, else returns None)";
+      .doc() = "Get histogram of bayer data (if enabled, else returns None)";
   c_metadata.def("rgb_histogram", &nvmanualcam::Metadata::getRgbHistogram)
-    .doc() = "Get rgb histogram (if enabled, else returns None)";
-  c_metadata.def_property_readonly("scene_lux", &nvmanualcam::Metadata::getSceneLux)
-    .doc() = "Get approximate scene illumination in lux.";
+      .doc() = "Get rgb histogram (if enabled, else returns None)";
+  c_metadata
+      .def_property_readonly("scene_lux", &nvmanualcam::Metadata::getSceneLux)
+      .doc() = "Get approximate scene illumination in lux.";
   c_metadata.def("sharpness_values", &nvmanualcam::Metadata::getSharpnessValues)
-    .doc() = "Get 64x64 array of sharpness values.";
-  c_metadata.def(
-    "sharpness_score",
-    py::overload_cast<Argus::Rectangle<float>>(&nvmanualcam::Metadata::getSharpnessScore),
-    py::arg("rect") = Argus::Rectangle<float>(0.0, 0.0, 1.0, 1.0)
-  ).doc() = "Get the sharpness score for the image or a ROI within it.";
+      .doc() = "Get 64x64 array of sharpness values.";
+  c_metadata
+      .def("sharpness_score",
+           py::overload_cast<Argus::Rectangle<float>>(
+               &nvmanualcam::Metadata::getSharpnessScore),
+           py::arg("rect") = Argus::Rectangle<float>(0.0, 0.0, 1.0, 1.0))
+      .doc() = "Get the sharpness score for the image or a ROI within it.";
   c_metadata.def("tonemap_curves", &nvmanualcam::Metadata::getToneMapCurves)
-    .doc() = "Get tonemap curves (if enabled, else retursn None)";
-  c_metadata.def_property_readonly("ae_locked", &nvmanualcam::Metadata::getAeLocked)
-    .doc() = "Returns true if Auto Exposure was locked for this capture.";
-  // c_metadata.def_property_readonly("ae_state", &nvmanualcam::Metadata::getAeState)
+      .doc() = "Get tonemap curves (if enabled, else retursn None)";
+  c_metadata
+      .def_property_readonly("ae_locked", &nvmanualcam::Metadata::getAeLocked)
+      .doc() = "Returns true if Auto Exposure was locked for this capture.";
+  // c_metadata.def_property_readonly("ae_state",
+  // &nvmanualcam::Metadata::getAeState)
   //   .doc() = "Get Auto Exposure state for this capture";
   c_metadata.def_property_readonly("awb_cct", &nvmanualcam::Metadata::getAwbCct)
-    .doc() = "Get Auto White Balance CCT (color temperature in Kelvin)";
-  c_metadata.def_property_readonly("awb_gains", &nvmanualcam::Metadata::getAwbGains)
-    .doc() = "Get Auto White Balance gains.";
+      .doc() = "Get Auto White Balance CCT (color temperature in Kelvin)";
+  c_metadata
+      .def_property_readonly("awb_gains", &nvmanualcam::Metadata::getAwbGains)
+      .doc() = "Get Auto White Balance gains.";
   // TODO(AE Regions and Argus::AcRegion)
   // TODO(AWB Regions, AWB Mode, AWB State)
   c_metadata.def("awb_estimate", &nvmanualcam::Metadata::getAwbWbEstimate)
-    .doc() = "Get Auto White Balance estimate (if available, else returns None)";
-  c_metadata.def_property_readonly("capture_id", &nvmanualcam::Metadata::getCaptureId)
-    .doc() = "Get capture id (close, but not quite the frame number)";
-  c_metadata.def("color_correction_matrix", &nvmanualcam::Metadata::getColorCorrectionMatrix)
-    .doc() = "Get color correction matrix for this capture (if available else None()";
-  c_metadata.def_property_readonly("color_correction_matrix_enable", &nvmanualcam::Metadata::getColorCorrectionMatrixEnable)
-    .doc() = "Returns true if color correction matrix is enabled for this capture.";
-  c_metadata.def_property_readonly("saturation", &nvmanualcam::Metadata::getColorSaturation)
-    .doc() = "Get saturation for this capture (0.0 - 1.0)";
+      .doc() =
+      "Get Auto White Balance estimate (if available, else returns None)";
+  c_metadata
+      .def_property_readonly("capture_id", &nvmanualcam::Metadata::getCaptureId)
+      .doc() = "Get capture id (close, but not quite the frame number)";
+  c_metadata
+      .def("color_correction_matrix",
+           &nvmanualcam::Metadata::getColorCorrectionMatrix)
+      .doc() =
+      "Get color correction matrix for this capture (if available else None()";
+  c_metadata
+      .def_property_readonly(
+          "color_correction_matrix_enable",
+          &nvmanualcam::Metadata::getColorCorrectionMatrixEnable)
+      .doc() =
+      "Returns true if color correction matrix is enabled for this capture.";
+  c_metadata
+      .def_property_readonly("saturation",
+                             &nvmanualcam::Metadata::getColorSaturation)
+      .doc() = "Get saturation for this capture (0.0 - 1.0)";
   // TODO(Argus::AeFlickerState)
-  c_metadata.def_property_readonly("focuser_position", &nvmanualcam::Metadata::getFocuserPosition)
-    .doc() = "Get focuser position (if applicable, else value is useless)";
-  c_metadata.def_property_readonly("frame_duration", &nvmanualcam::Metadata::getFrameDuration)
-    .doc() = "Get the duration it took to generate the associated frame in NS";
-  c_metadata.def_property_readonly("frame_readout_time", &nvmanualcam::Metadata::getFrameReadoutTime)
-    .doc() = "Get the frame readout time in NS.";
-  c_metadata.def_property_readonly("isp_digital_gain", &nvmanualcam::Metadata::getIspDigitalGain)
-    .doc() = "Get the ISP digital gain for this capture.";
-  c_metadata.def_property_readonly("sensor_analog_gain", &nvmanualcam::Metadata::getSensorAnalogGain)
-    .doc() = "Get the analog gain for this capture.";
-  c_metadata.def_property_readonly("sensor_exposure_time", &nvmanualcam::Metadata::getSensorExposureTime)
-    .doc() = "Get the sensor exposure time (in NS)";
-  c_metadata.def_property_readonly("sensor_sensitivity", &nvmanualcam::Metadata::getSensorSensitivity)
-    .doc() = "Get the sensor sensitivity (ISO value)";
-  c_metadata.def_property_readonly("sensor_timestamp", &nvmanualcam::Metadata::getSensorTimestamp)
-    .doc() = "Get the sensor timestamp.";
+  c_metadata
+      .def_property_readonly("focuser_position",
+                             &nvmanualcam::Metadata::getFocuserPosition)
+      .doc() = "Get focuser position (if applicable, else value is useless)";
+  c_metadata
+      .def_property_readonly("frame_duration",
+                             &nvmanualcam::Metadata::getFrameDuration)
+      .doc() =
+      "Get the duration it took to generate the associated frame in NS";
+  c_metadata
+      .def_property_readonly("frame_readout_time",
+                             &nvmanualcam::Metadata::getFrameReadoutTime)
+      .doc() = "Get the frame readout time in NS.";
+  c_metadata
+      .def_property_readonly("isp_digital_gain",
+                             &nvmanualcam::Metadata::getIspDigitalGain)
+      .doc() = "Get the ISP digital gain for this capture.";
+  c_metadata
+      .def_property_readonly("sensor_analog_gain",
+                             &nvmanualcam::Metadata::getSensorAnalogGain)
+      .doc() = "Get the analog gain for this capture.";
+  c_metadata
+      .def_property_readonly("sensor_exposure_time",
+                             &nvmanualcam::Metadata::getSensorExposureTime)
+      .doc() = "Get the sensor exposure time (in NS)";
+  c_metadata
+      .def_property_readonly("sensor_sensitivity",
+                             &nvmanualcam::Metadata::getSensorSensitivity)
+      .doc() = "Get the sensor sensitivity (ISO value)";
+  c_metadata
+      .def_property_readonly("sensor_timestamp",
+                             &nvmanualcam::Metadata::getSensorTimestamp)
+      .doc() = "Get the sensor timestamp.";
 }

--- a/src/pymod.cpp
+++ b/src/pymod.cpp
@@ -4,10 +4,10 @@
 // #include <bits/stdint-uintn.h>
 
 #include "gst/gst.h"
-
 #include "gst/gstbuffer.h"
-#include "gst/gstpad.h"
+
 #include "pybind11/pybind11.h"
+#include "pybind11/detail/common.h"
 #include "pybind11/operators.h"
 #include "pybind11/cast.h"
 #include "pybind11/stl.h"
@@ -20,7 +20,7 @@ namespace py = pybind11;
 // // https://stackoverflow.com/questions/47487888/pybind11-template-class-of-many-types/47749076
 template <typename T>
 void declare_rectangle(py::module& m, std::string typestr) {
-  py::class_<Argus::Rectangle<T>>(m, (typestr + std::string("Rectangle")).c_str())
+  py::class_<Argus::Rectangle<T>>(m, (typestr + "Rectangle").c_str())
     .def(py::init<T, T, T, T>(), py::arg("left"), py::arg("top"), py::arg("right"), py::arg("bottom"))
     .def_property_readonly("left", py::overload_cast<>(&Argus::Rectangle<T>::left))
     .def_property_readonly("top", py::overload_cast<>(&Argus::Rectangle<T>::top))
@@ -28,6 +28,24 @@ void declare_rectangle(py::module& m, std::string typestr) {
     .def_property_readonly("bottom", py::overload_cast<>(&Argus::Rectangle<T>::bottom));
 }
 
+template <typename T>
+void declare_rgb_tuple(py::module& m, std::string typestr) {
+  py::class_<Argus::RGBTuple<T>>(m, (typestr + "RGBTuple").c_str())
+    .def(py::init<T, T, T>(), py::arg("r"), py::arg("g"), py::arg("b"))
+    .def_property_readonly("r", py::overload_cast<>(&Argus::RGBTuple<T>::r))
+    .def_property_readonly("g", py::overload_cast<>(&Argus::RGBTuple<T>::g))
+    .def_property_readonly("b", py::overload_cast<>(&Argus::RGBTuple<T>::b));
+}
+
+template <typename T>
+void declare_bayer_tuple(py::module& m, std::string typestr) {
+  py::class_<Argus::BayerTuple<T>>(m, (typestr + "BayerTuple").c_str())
+    .def(py::init<T, T, T, T>(), py::arg("r"), py::arg("g_even"), py::arg("g_odd"), py::arg("b"))
+    .def_property_readonly("r", py::overload_cast<>(&Argus::BayerTuple<T>::r))
+    .def_property_readonly("g_even", py::overload_cast<>(&Argus::BayerTuple<T>::gEven))
+    .def_property_readonly("g_odd", py::overload_cast<>(&Argus::BayerTuple<T>::gOdd))
+    .def_property_readonly("b", py::overload_cast<>(&Argus::BayerTuple<T>::b));
+}
 
 // because pybind doesn't detect this correctly on ubuntu 20.04 (or 18.04)]
 // (or I am doing something wrong). absl::optional or boost::optional can
@@ -48,6 +66,10 @@ PYBIND11_MODULE(nvmanual, m) {
 
   declare_rectangle<float>(m_argus, "Float");  // argus.FloatRectangle
   declare_rectangle<uint32_t>(m_argus, "Int");  // argus.IntRectangle
+  declare_rgb_tuple<float>(m_argus, "Float");  // argus.FloatRGBTuple
+  declare_rgb_tuple<uint32_t>(m_argus, "Int");  // argus.IntRGBTuple
+  declare_bayer_tuple<float>(m_argus, "Float");  // argus.FloatBayerTuple
+  declare_bayer_tuple<uint32_t>(m_argus, "Int");  // argus.IntBayerTuple
 
   py::class_<nvmanualcam::Metadata> c_metadata(m, "Metadata");
   c_metadata.def_static("from_buffer", [](py::object pygobject_buf) {
@@ -61,9 +83,12 @@ PYBIND11_MODULE(nvmanual, m) {
       }
       return nvmanualcam::Metadata::create(buf);
     }, py::arg("buf")).doc() = "create nvmanual.Metadata from a Gst.Buffer";
-    // .def("bayer_histogram", &nvmanualcam::Metadata::getBayerHistogram)
-    // .def("rgb_histogram", &nvmanualcam::Metadata::getRgbHistogram)
-  c_metadata.def_property_readonly("scene_lux", &nvmanualcam::Metadata::getSceneLux);
+  c_metadata.def("bayer_histogram", &nvmanualcam::Metadata::getBayerHistogram)
+    .doc() = "Get histogram of bayer data (if enabled, else returns None)";
+  c_metadata.def("rgb_histogram", &nvmanualcam::Metadata::getRgbHistogram)
+    .doc() = "Get rgb histogram (if enabled, else returns None)";
+  c_metadata.def_property_readonly("scene_lux", &nvmanualcam::Metadata::getSceneLux)
+    .doc() = "Get approximate scene illumination in lux.";
   c_metadata.def(
     "sharpness_score",
     py::overload_cast<Argus::Rectangle<float>>(&nvmanualcam::Metadata::getSharpnessScore),

--- a/src/pymod.cpp
+++ b/src/pymod.cpp
@@ -56,7 +56,7 @@ void declare_array_2d(py::module& m, std::string typestr) {
     py::class_<Argus::Array2D<T>>(m, (typestr + "Array2D").c_str())
       .def_static("from_xy", [](uint32_t x, uint32_t y){
         return std::make_unique<Argus::Array2D<T>>(Argus::Size2D(x, y));
-      })
+      }, py::arg("x"), py::arg("y"))
       .def("__len__", [](const Argus::Array2D<T> &a){ return a.size().area(); })
       .def("__iter__", [](const Argus::Array2D<T> &a) {
         return py::make_iterator(a.begin(), a.end());

--- a/subprojects/pybind11.wrap
+++ b/subprojects/pybind11.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = pybind11-2.6.1
+source_url = https://github.com/pybind/pybind11/archive/v2.6.1.tar.gz
+source_filename = pybind11-2.6.1.tar.gz
+source_hash = cdbe326d357f18b83d10322ba202d69f11b2f49e2d87ade0dc2be0c5c34f8e2a
+patch_url = https://wrapdb.mesonbuild.com/v2/pybind11_2.6.1-1/get_patch
+patch_filename = pybind11-2.6.1-1-wrap.zip
+patch_hash = 6de5477598b56c8a2e609196420c783ac35b79a31d6622121602e6ade6b3cee8
+
+[provide]
+pybind11 = pybind11_dep
+

--- a/test/meson.build
+++ b/test/meson.build
@@ -36,3 +36,7 @@ subdir('googletest')
 subdir('gst-check')
 subdir('exitcode')
 subdir('gst-launch')
+if python3.found() and dependency('python3', required: false).found()
+  test_envs += 'PYMOD_PATH=' + pymod_path
+  subdir('python')
+endif

--- a/test/python/meson.build
+++ b/test/python/meson.build
@@ -1,0 +1,11 @@
+python_tests = [
+  'test_metadata.py',
+]
+
+foreach t : python_tests
+  test(t, python3,
+    args: [files(t)],
+    env: test_envs,
+    suite: 'python',
+  )
+endforeach

--- a/test/python/meson.build
+++ b/test/python/meson.build
@@ -1,4 +1,5 @@
 python_tests = [
+  'test_argus_types.py',
   'test_metadata.py',
 ]
 

--- a/test/python/test_argus_types.py
+++ b/test/python/test_argus_types.py
@@ -13,13 +13,6 @@ class TestRectangle(unittest.TestCase):
         "IntRectangle": int,
     }
 
-    PROPS = (
-        'left',
-        'top',
-        'right',
-        'bottom'
-    )
-
     def test_rectangle_values(self):
         for clsname, T in self.TEMPLATE_MAP.items():
             values = {
@@ -29,7 +22,7 @@ class TestRectangle(unittest.TestCase):
                 'bottom': T(4),
             }
             with self.subTest(clsname):
-                cls = getattr(nvmanual, clsname)
+                cls = getattr(nvmanual.argus, clsname)
                 rect = cls(**values)
                 for k, v in values.items():
                     self.assertEqual(getattr(rect, k), v)

--- a/test/python/test_argus_types.py
+++ b/test/python/test_argus_types.py
@@ -7,10 +7,12 @@ sys.path.append(PYMOD_PATH)
 
 import nvmanual
 
+# TODO(mdegans): these test cases can probably be programmatically created
+
 class TestRectangle(unittest.TestCase):
+    TYPES = (float, int)
     TEMPLATE_MAP = {
-        "FloatRectangle": float,
-        "IntRectangle": int,
+        f"{t.__class__.__name__.capitalize()}Rectangle": t for t in TYPES
     }
 
     def test_rectangle_values(self):
@@ -27,3 +29,43 @@ class TestRectangle(unittest.TestCase):
                 for k, v in values.items():
                     self.assertEqual(getattr(rect, k), v)
 
+
+class TestRGBTuple(unittest.TestCase):
+    TYPES = (float, int)
+    TEMPLATE_MAP = {
+        f"{t.__class__.__name__.capitalize()}RGBTuple": t for t in TYPES
+    }
+
+    def test_rgb_tuple(self):
+        for clsname, T in self.TEMPLATE_MAP.items():
+            values = {
+                'r': T(1),
+                'g': T(2),
+                'b': T(3),
+            }
+            with self.subTest(clsname):
+                cls = getattr(nvmanual.argus, clsname)
+                rgb_tuple = cls(**values)
+                for k, v in values.items():
+                    self.assertEqual(getattr(rgb_tuple, k), v)
+
+
+class TestBayerTuple(unittest.TestCase):
+    TYPES = (float, int)
+    TEMPLATE_MAP = {
+        f"{t.__class__.__name__.capitalize()}BayerTuple": t for t in TYPES
+    }
+
+    def test_rgb_tuple(self):
+        for clsname, T in self.TEMPLATE_MAP.items():
+            values = {
+                'r': T(1),
+                'g_even': T(2),
+                'g_odd': T(3),
+                'b': T(4),
+            }
+            with self.subTest(clsname):
+                cls = getattr(nvmanual.argus, clsname)
+                bayer_tuple = cls(**values)
+                for k, v in values.items():
+                    self.assertEqual(getattr(bayer_tuple, k), v)

--- a/test/python/test_argus_types.py
+++ b/test/python/test_argus_types.py
@@ -12,7 +12,7 @@ import nvmanual
 class TestRectangle(unittest.TestCase):
     TYPES = (float, int)
     TEMPLATE_MAP = {
-        f"{t.__class__.__name__.capitalize()}Rectangle": t for t in TYPES
+        f"{t.__name__.capitalize()}Rectangle": t for t in TYPES
     }
 
     def test_rectangle_values(self):
@@ -33,7 +33,7 @@ class TestRectangle(unittest.TestCase):
 class TestRGBTuple(unittest.TestCase):
     TYPES = (float, int)
     TEMPLATE_MAP = {
-        f"{t.__class__.__name__.capitalize()}RGBTuple": t for t in TYPES
+        f"{t.__name__.capitalize()}RGBTuple": t for t in TYPES
     }
 
     def test_rgb_tuple(self):
@@ -53,7 +53,7 @@ class TestRGBTuple(unittest.TestCase):
 class TestBayerTuple(unittest.TestCase):
     TYPES = (float, int)
     TEMPLATE_MAP = {
-        f"{t.__class__.__name__.capitalize()}BayerTuple": t for t in TYPES
+        f"{t.__name__.capitalize()}BayerTuple": t for t in TYPES
     }
 
     def test_rgb_tuple(self):
@@ -69,3 +69,51 @@ class TestBayerTuple(unittest.TestCase):
                 bayer_tuple = cls(**values)
                 for k, v in values.items():
                     self.assertEqual(getattr(bayer_tuple, k), v)
+
+
+class TestArray2D(unittest.TestCase):
+    SUBTYPES = (
+        nvmanual.argus.FloatBayerTupleArray2D,
+    )
+
+    def test_from_xy(self):
+        # also tests __len__
+        sz = 16
+        for t in self.SUBTYPES:
+            with self.subTest(t.__class__.__name__):
+                i = t.from_xy(x=sz, y=sz)
+                self.assertIsInstance(i, t)
+                self.assertEqual(sz * sz, len(i))
+
+    def test_at(self):
+        sz = 16
+        for t in self.SUBTYPES:
+            with self.subTest(t.__class__.__name__):
+                i = t.from_xy(x=sz, y=sz)
+                e = i.at(x=0, y=0)
+                e = i.at(x=sz - 1, y=sz - 1)
+                with self.assertRaises(IndexError):
+                    i.at(x=sz, y=0)
+                with self.assertRaises(IndexError):
+                    i.at(x=0, y=16)
+
+    def test_getitem(self):
+        sz = 16
+        for t in self.SUBTYPES:
+            with self.subTest(t.__class__.__name__):
+                i = t.from_xy(x=sz, y=sz)
+                e = i[0]
+                e = i[sz * sz - 1]
+                with self.assertRaises(IndexError):
+                    i[sz * sz]
+
+    def test_iter(self):
+        sz = 16
+        for t in self.SUBTYPES:
+            with self.subTest(t.__class__.__name__):
+                i = t.from_xy(x=sz, y=sz)
+                for e in i:
+                    self.assertIsInstance(e, nvmanual.argus.FloatBayerTuple)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/python/test_argus_types.py
+++ b/test/python/test_argus_types.py
@@ -9,19 +9,18 @@ import nvmanual
 
 # TODO(mdegans): these test cases can probably be programmatically created
 
+
 class TestRectangle(unittest.TestCase):
     TYPES = (float, int)
-    TEMPLATE_MAP = {
-        f"{t.__name__.capitalize()}Rectangle": t for t in TYPES
-    }
+    TEMPLATE_MAP = {f"{t.__name__.capitalize()}Rectangle": t for t in TYPES}
 
     def test_rectangle_values(self):
         for clsname, T in self.TEMPLATE_MAP.items():
             values = {
-                'left': T(1),
-                'top': T(2),
-                'right': T(3),
-                'bottom': T(4),
+                "left": T(1),
+                "top": T(2),
+                "right": T(3),
+                "bottom": T(4),
             }
             with self.subTest(clsname):
                 cls = getattr(nvmanual.argus, clsname)
@@ -32,16 +31,14 @@ class TestRectangle(unittest.TestCase):
 
 class TestRGBTuple(unittest.TestCase):
     TYPES = (float, int)
-    TEMPLATE_MAP = {
-        f"{t.__name__.capitalize()}RGBTuple": t for t in TYPES
-    }
+    TEMPLATE_MAP = {f"{t.__name__.capitalize()}RGBTuple": t for t in TYPES}
 
     def test_rgb_tuple(self):
         for clsname, T in self.TEMPLATE_MAP.items():
             values = {
-                'r': T(1),
-                'g': T(2),
-                'b': T(3),
+                "r": T(1),
+                "g": T(2),
+                "b": T(3),
             }
             with self.subTest(clsname):
                 cls = getattr(nvmanual.argus, clsname)
@@ -52,17 +49,15 @@ class TestRGBTuple(unittest.TestCase):
 
 class TestBayerTuple(unittest.TestCase):
     TYPES = (float, int)
-    TEMPLATE_MAP = {
-        f"{t.__name__.capitalize()}BayerTuple": t for t in TYPES
-    }
+    TEMPLATE_MAP = {f"{t.__name__.capitalize()}BayerTuple": t for t in TYPES}
 
     def test_rgb_tuple(self):
         for clsname, T in self.TEMPLATE_MAP.items():
             values = {
-                'r': T(1),
-                'g_even': T(2),
-                'g_odd': T(3),
-                'b': T(4),
+                "r": T(1),
+                "g_even": T(2),
+                "g_odd": T(3),
+                "b": T(4),
             }
             with self.subTest(clsname):
                 cls = getattr(nvmanual.argus, clsname)
@@ -72,9 +67,7 @@ class TestBayerTuple(unittest.TestCase):
 
 
 class TestArray2D(unittest.TestCase):
-    SUBTYPES = (
-        nvmanual.argus.FloatBayerTupleArray2D,
-    )
+    SUBTYPES = (nvmanual.argus.FloatBayerTupleArray2D,)
 
     def test_from_xy(self):
         # also tests __len__
@@ -114,6 +107,7 @@ class TestArray2D(unittest.TestCase):
                 i = t.from_xy(x=sz, y=sz)
                 for e in i:
                     self.assertIsInstance(e, nvmanual.argus.FloatBayerTuple)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/python/test_argus_types.py
+++ b/test/python/test_argus_types.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import unittest
+
+PYMOD_PATH = os.environ["PYMOD_PATH"]
+sys.path.append(PYMOD_PATH)
+
+import nvmanual
+
+class TestRectangle(unittest.TestCase):
+    TEMPLATE_MAP = {
+        "FloatRectangle": float,
+        "IntRectangle": int,
+    }
+
+    PROPS = (
+        'left',
+        'top',
+        'right',
+        'bottom'
+    )
+
+    def test_rectangle_values(self):
+        for clsname, T in self.TEMPLATE_MAP.items():
+            values = {
+                'left': T(1),
+                'top': T(2),
+                'right': T(3),
+                'bottom': T(4),
+            }
+            with self.subTest(clsname):
+                cls = getattr(nvmanual, clsname)
+                rect = cls(**values)
+                for k, v in values.items():
+                    self.assertEqual(getattr(rect, k), v)
+

--- a/test/python/test_metadata.py
+++ b/test/python/test_metadata.py
@@ -60,13 +60,16 @@ def metadata_probe(pad: Gst.Pad, info: Gst.PadProbeInfo, data: Any):
         assert type(roi_sharpness) is float
         print(f"roi sharpness: {roi_sharpness}")
 
-        # t_curve = meta.tonemap_curve()
+        t_curve = meta.tonemap_curves()
+        # FIXME(mdegans): not very important for client's purpose but in the
+        # future it might be.
         # assert t_curve is not None
+        print(f"tonemap curves: {t_curve}")
 
         # ccx = meta.color_correction_matrix()
         # assert ccx is not None
-    except AssertionError as e:
-        print(e)
+    except Exception as e:
+        print(e, flush=True)
         retcode = 1
 
     return Gst.PadProbeReturn.OK

--- a/test/python/test_metadata.py
+++ b/test/python/test_metadata.py
@@ -1,0 +1,86 @@
+# this should mirror the logic of test_metadata.cpp
+import os
+import sys
+
+from typing import Optional, Any
+
+import gi
+gi.require_version("Gst", "1.0")
+
+from gi.repository import Gst
+
+PYMOD_PATH = os.environ["PYMOD_PATH"]
+sys.path.append(PYMOD_PATH)
+
+import nvmanual
+
+def metadata_probe(pad: Gst.Pad, info: Gst.PadProbeInfo, data: Any):
+    # todo: comprehensive checks of each
+    meta = nvmanual.Metadata.from_buffer(info.get_buffer())
+    assert meta is not None
+
+    # b_hist = meta.bayer_histogram()
+    # assert b_hist is not None
+
+    # rgb_hist = meta.rgb_histogram()
+    # assert rgb_hist is not None
+
+    lux = meta.scene_lux()
+    assert type(lux) is float
+    print(f"scene lux: {lux}")
+
+    # s_values = meta.sharpness_values()
+    # assert s_values is not None
+
+    # t_curve = meta.tonemap_curve()
+    # assert t_curve is not None
+
+    # ccx = meta.color_correction_matrix()
+    # assert ccx is not None
+
+    return Gst.PadProbeReturn.OK
+
+
+def main():
+    Gst.init(None)
+
+    pipe = Gst.Pipeline.new()
+    try:
+        assert pipe is not None
+
+        camera = Gst.ElementFactory.make("nvmanualcamerasrc", "camera")
+        assert camera is not None
+
+        fakesink = Gst.ElementFactory.make("fakesink", "fakesink")
+        assert fakesink is not None
+
+        assert pipe.add(camera)
+        assert pipe.add(fakesink)
+
+        assert camera.link(fakesink)
+
+        camera.set_property("bayer-sharpness-map", True)
+        camera.set_property("metadata", True)
+        camera.set_property("num-buffers", 10)
+
+        pad = fakesink.get_static_pad("sink")
+        assert pad is not None
+
+        pad.add_probe(Gst.PadProbeType.BUFFER, metadata_probe, None)
+
+        assert pipe.set_state(Gst.State.PLAYING) != Gst.StateChangeReturn.FAILURE
+
+        bus = pipe.get_bus()
+        assert bus is not None
+
+        msg = bus.timed_pop_filtered(Gst.CLOCK_TIME_NONE, (Gst.MessageType.ERROR | Gst.MessageType.EOS))
+        assert msg.type == Gst.MessageType.EOS
+
+    finally:
+        assert pipe.set_state(Gst.State.NULL) != Gst.StateChangeReturn.FAILURE
+
+    return 0
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(main())

--- a/test/python/test_metadata.py
+++ b/test/python/test_metadata.py
@@ -19,6 +19,8 @@ retcode = 0
 
 
 def metadata_probe(pad: Gst.Pad, info: Gst.PadProbeInfo, data: Any):
+    global retcode
+
     try:
         # To get Metadata in python, use the `from_buffer` method and supply
         # it a Gst.Buffer. Using a probe is just one way of doing this. There is

--- a/test/python/test_metadata.py
+++ b/test/python/test_metadata.py
@@ -24,11 +24,26 @@ def metadata_probe(pad: Gst.Pad, info: Gst.PadProbeInfo, data: Any):
         meta = nvmanual.Metadata.from_buffer(info.get_buffer())
         assert meta is not None
 
-        # b_hist = meta.bayer_histogram()
-        # assert b_hist is not None
+        b_hist = meta.bayer_histogram()
+        assert b_hist is not None
+        assert type(b_hist) is list
+        assert len(b_hist) is 256
+        bayer_tuple = b_hist[0]
+        assert type(bayer_tuple.r) is int
+        assert type(bayer_tuple.g_even) is int
+        assert type(bayer_tuple.g_odd) is int
+        assert type(bayer_tuple.b) is int
+        print(f"got bayer histogram of length: {len(b_hist)}")
 
-        # rgb_hist = meta.rgb_histogram()
-        # assert rgb_hist is not None
+        rgb_hist = meta.rgb_histogram()
+        assert rgb_hist is not None
+        assert type(rgb_hist) is list
+        assert len(rgb_hist) == 256
+        rgb_tuple = rgb_hist[0]
+        assert type(rgb_tuple.r) is int
+        assert type(rgb_tuple.g) is int
+        assert type(rgb_tuple.b) is int
+        print(f"got rgb histogram of length: {len(rgb_hist)}")
 
         lux = meta.scene_lux
         assert type(lux) is float
@@ -50,7 +65,8 @@ def metadata_probe(pad: Gst.Pad, info: Gst.PadProbeInfo, data: Any):
 
         # ccx = meta.color_correction_matrix()
         # assert ccx is not None
-    except AssertionError:
+    except AssertionError as e:
+        print(e)
         retcode = 1
 
     return Gst.PadProbeReturn.OK

--- a/test/python/test_metadata.py
+++ b/test/python/test_metadata.py
@@ -80,6 +80,26 @@ def metadata_probe(pad: Gst.Pad, info: Gst.PadProbeInfo, data: Any):
         assert type(roi_sharpness) is float
         print(f"roi sharpness: {roi_sharpness}")
 
+        # these are the raw sharpness values. Prefer using or modifying
+        # sharpness_score as operating on this from python is slow because
+        # python objects are being constantly created.
+        s_values = meta.sharpness_values()
+        print(f"sharpness values length: {len(s_values)}")
+        assert type(s_values) is nvmanual.argus.FloatBayerTupleArray2D
+        for v in s_values:
+            assert type(v) is nvmanual.argus.FloatBayerTuple
+        assert type(s_values.at(x=63, y=63)) is nvmanual.argus.FloatBayerTuple
+        try:
+            s_values.at(64, 0)
+        except IndexError as e:
+            print("sharpness values x index check ok")
+            pass
+        try:
+            s_values.at(0, 64)
+        except IndexError as e:
+            print("sharpness values y index check ok")
+            pass
+
         # These are tonemap curves. They're not currently available and this
         # is a bug. Whose fault that is, IDK yet.
         t_curve = meta.tonemap_curves()


### PR DESCRIPTION
This work allows accessing Argus metadata like the Bayer histogram, RGB histogram, sharpness scores, and so forth in Python. Just create `nvmanual.Metadata.from_buffer(gstreamer_gst_buffer)` and off you go.

* add Python bindings for Argus metadata. Usage is in `test/python/...`.
* TODO: html documentation
